### PR TITLE
Feat: 등록 모집글 조회 및 신청자 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/matchFit/participation/entity/Participation.java
+++ b/src/main/java/com/matchFit/participation/entity/Participation.java
@@ -13,8 +13,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Participation extends BaseEntity {
 	
 	@Id

--- a/src/main/java/com/matchFit/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/matchFit/participation/repository/ParticipationRepository.java
@@ -1,5 +1,7 @@
 package com.matchFit.participation.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.matchFit.participation.entity.ApplicationStatus;
@@ -15,4 +17,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 	// 신청 승인된 사용자만 count
 	int countByPost_IdAndStatus(Long postId, ApplicationStatus status);
 	
+	
+	List<Participation> findAllByPostId(Long postId);
+
 }

--- a/src/main/java/com/matchFit/participation/service/ParticipationService.java
+++ b/src/main/java/com/matchFit/participation/service/ParticipationService.java
@@ -1,14 +1,21 @@
 package com.matchFit.participation.service;
 
+import java.util.List;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 
 import com.matchFit.participation.entity.ApplicationStatus;
 import com.matchFit.participation.entity.Participation;
 import com.matchFit.participation.repository.ParticipationRepository;
+import com.matchFit.post.dto.response.GetMyPostApplicant;
+import com.matchFit.post.dto.response.GetMyPostApplicants;
 import com.matchFit.post.entity.Post;
 import com.matchFit.post.repository.PostRepository;
 import com.matchFit.user.entity.User;
 import com.matchFit.user.repository.UserRepository;
+import com.matchFit.user.security.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
 
@@ -41,4 +48,19 @@ public class ParticipationService {
 		
 	}
 
+	
+	public GetMyPostApplicants getApplicantsByPost(Long postId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집글입니다."));
+        User currentUser = userDetails.getUser();
+        
+        if (!post.getUser().getId().equals(currentUser.getId())) {
+            throw new AccessDeniedException("본인의 모집글만 조회할 수 있습니다.");
+        }
+        
+        List<Participation> applicants = participationRepository.findAllByPostId(postId);
+        List<GetMyPostApplicant> applicantDtos = GetMyPostApplicant.from(applicants);
+        
+        return GetMyPostApplicants.of(applicantDtos);
+    }
 }

--- a/src/main/java/com/matchFit/post/controller/PostController.java
+++ b/src/main/java/com/matchFit/post/controller/PostController.java
@@ -1,38 +1,33 @@
 package com.matchFit.post.controller;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import com.matchFit.participation.dto.response.MessageResponse;
 import com.matchFit.participation.service.ParticipationService;
 import com.matchFit.post.dto.PostInfoResponseDto;
 import com.matchFit.post.dto.PostRequestDto;
-import com.matchFit.post.service.PostService;
-import com.matchFit.user.service.UserService;
-
-
-import java.time.LocalDate;
-import java.time.YearMonth;
-import java.util.Collections;
-
-import org.springframework.format.annotation.DateTimeFormat;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-
+import com.matchFit.post.dto.response.GetMyPosts;
 import com.matchFit.post.dto.response.GetPostsCalender;
 import com.matchFit.post.dto.response.GetPostsList;
-import com.matchFit.post.entity.Post;
 import com.matchFit.post.entity.Sports;
+import com.matchFit.post.service.PostService;
 import com.matchFit.user.entity.Gender;
-
+import com.matchFit.user.security.CustomUserDetails;
+import com.matchFit.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,15 +40,11 @@ public class PostController {
 	private final UserService userService;
 	private final ParticipationService participationService;
 	
-	// 모집글 생성
-	@PostMapping("")
-	public ResponseEntity<Post> createPost(@RequestBody PostRequestDto dto,
-											@AuthenticationPrincipal UserDetails userDetails ) {
-		
-		String email = userDetails.getUsername();
-        Long userId = userService.findUserIdByEmail(email);
-		Post post = postService.create(dto, userId);
-		return ResponseEntity.ok(post);		
+	@PostMapping
+	public ResponseEntity<String> createPosts(@RequestBody PostRequestDto dto,
+			@AuthenticationPrincipal CustomUserDetails userDetails) {
+		postService.create(dto, userDetails);
+		return ResponseEntity.status(HttpStatus.CREATED).body("모집글 생성 성공");		
 	}
 	
 	// 모집글 상세 조회
@@ -110,5 +101,11 @@ public class PostController {
 		GetPostsCalender postsCalender = postService.findByMonth(month);
 		return ResponseEntity.ok(postsCalender);
 	}
+	
+	@GetMapping("/mine")
+    public ResponseEntity<GetMyPosts> getMyPosts(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        GetMyPosts myPosts = postService.getMyPosts(userDetails);
+        return ResponseEntity.ok(myPosts);
+    }
 
 }

--- a/src/main/java/com/matchFit/post/controller/PostController.java
+++ b/src/main/java/com/matchFit/post/controller/PostController.java
@@ -20,6 +20,7 @@ import com.matchFit.participation.dto.response.MessageResponse;
 import com.matchFit.participation.service.ParticipationService;
 import com.matchFit.post.dto.PostInfoResponseDto;
 import com.matchFit.post.dto.PostRequestDto;
+import com.matchFit.post.dto.response.GetMyPostApplicants;
 import com.matchFit.post.dto.response.GetMyPosts;
 import com.matchFit.post.dto.response.GetPostsCalender;
 import com.matchFit.post.dto.response.GetPostsList;
@@ -107,5 +108,14 @@ public class PostController {
         GetMyPosts myPosts = postService.getMyPosts(userDetails);
         return ResponseEntity.ok(myPosts);
     }
+	
+	@GetMapping("/{postId}/applicants")
+	public ResponseEntity<GetMyPostApplicants> getApplicants(
+	    @PathVariable Long postId,
+	    @AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		GetMyPostApplicants applicants = participationService.getApplicantsByPost(postId, userDetails);
+	    return ResponseEntity.ok(applicants);
+	}
 
 }

--- a/src/main/java/com/matchFit/post/dto/PostRequestDto.java
+++ b/src/main/java/com/matchFit/post/dto/PostRequestDto.java
@@ -4,9 +4,10 @@ import java.time.LocalDateTime;
 
 import com.matchFit.post.entity.Post;
 import com.matchFit.post.entity.Sports;
-import com.matchFit.post.entity.Town;
 import com.matchFit.post.entity.Status;
+import com.matchFit.post.entity.Town;
 import com.matchFit.user.entity.Gender;
+import com.matchFit.user.entity.User;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -27,7 +28,7 @@ public class PostRequestDto {
 	private Integer maxPeople;
 	private LocalDateTime date;
 	
-	public Post toEntity() {
+	public Post toEntity(User user) {
 		return Post.builder()
 				.title(this.title)
 				.description(this.description)
@@ -40,6 +41,7 @@ public class PostRequestDto {
 	            .town(this.town)
 	            .maxPeople(this.maxPeople)
 	            .date(this.date)
+	            .user(user)
 	            .build();
 	}
 }

--- a/src/main/java/com/matchFit/post/dto/response/GetMyPost.java
+++ b/src/main/java/com/matchFit/post/dto/response/GetMyPost.java
@@ -1,0 +1,16 @@
+package com.matchFit.post.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMyPost {
+	private String title;
+    private LocalDateTime date;
+    private Integer currentPeople;
+    private Integer maxPeople;
+    private String status;
+}

--- a/src/main/java/com/matchFit/post/dto/response/GetMyPostApplicant.java
+++ b/src/main/java/com/matchFit/post/dto/response/GetMyPostApplicant.java
@@ -1,0 +1,29 @@
+package com.matchFit.post.dto.response;
+
+import java.util.List;
+
+import com.matchFit.participation.entity.Participation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMyPostApplicant {
+	private Long userId;
+    private String nickname;
+    private String gender;
+    private Integer age;
+    private String status;
+	public static List<GetMyPostApplicant> from(List<Participation> applicants) {
+		return applicants.stream()
+				.map(applicant -> 
+				new GetMyPostApplicant(
+						applicant.getUser().getId(), 
+						applicant.getUser().getNickname(),
+						applicant.getUser().getGender().getLabel(), 
+						applicant.getUser().getAge(),
+						applicant.getStatus().toString()))
+				.toList();
+	}
+}

--- a/src/main/java/com/matchFit/post/dto/response/GetMyPostApplicants.java
+++ b/src/main/java/com/matchFit/post/dto/response/GetMyPostApplicants.java
@@ -1,0 +1,16 @@
+package com.matchFit.post.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMyPostApplicants {
+	private List<GetMyPostApplicant> applicants;
+
+	public static GetMyPostApplicants of(List<GetMyPostApplicant> applicantDtos) {
+		return new GetMyPostApplicants(applicantDtos);
+	}
+}

--- a/src/main/java/com/matchFit/post/dto/response/GetMyPosts.java
+++ b/src/main/java/com/matchFit/post/dto/response/GetMyPosts.java
@@ -1,0 +1,16 @@
+package com.matchFit.post.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMyPosts {
+	private List<GetMyPost> posts;
+
+	public static GetMyPosts of(List<GetMyPost> myPosts) {
+		return new GetMyPosts(myPosts);
+	}
+}

--- a/src/main/java/com/matchFit/post/entity/Post.java
+++ b/src/main/java/com/matchFit/post/entity/Post.java
@@ -5,9 +5,6 @@ import java.time.LocalDateTime;
 import com.matchFit.common.BaseEntity;
 import com.matchFit.user.entity.Gender;
 import com.matchFit.user.entity.User;
-import com.matchFit.post.entity.Status;
-import com.matchFit.post.entity.Sports;
-import com.matchFit.post.entity.Town;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,7 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/matchFit/post/repository/PostRepository.java
+++ b/src/main/java/com/matchFit/post/repository/PostRepository.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -35,5 +34,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     
     List<Post> findAllByDateBetween(LocalDateTime start, LocalDateTime end);
+    
+    List<Post> findByUserIdOrderByCreatedAtDesc(Long userId);
 }
 

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -1,13 +1,5 @@
 package com.matchFit.post.service;
 
-import com.matchFit.participation.entity.ApplicationStatus;
-import com.matchFit.participation.repository.ParticipationRepository;
-import com.matchFit.post.dto.PostInfoResponseDto;
-import com.matchFit.post.dto.PostRequestDto;
-	
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.YearMonth;
@@ -17,9 +9,15 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.matchFit.participation.entity.ApplicationStatus;
+import com.matchFit.participation.repository.ParticipationRepository;
+import com.matchFit.post.dto.PostInfoResponseDto;
+import com.matchFit.post.dto.PostRequestDto;
+import com.matchFit.post.dto.response.GetMyPost;
+import com.matchFit.post.dto.response.GetMyPosts;
 import com.matchFit.post.dto.response.GetPost;
 import com.matchFit.post.dto.response.GetPostCalender;
 import com.matchFit.post.dto.response.GetPostsCalender;
@@ -31,6 +29,10 @@ import com.matchFit.post.repository.PostRepository;
 import com.matchFit.user.entity.Gender;
 import com.matchFit.user.entity.User;
 import com.matchFit.user.repository.UserRepository;
+import com.matchFit.user.security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+
 
 @Transactional
 @Service
@@ -87,20 +89,9 @@ public class PostService {
 	}
 	
 	// 모집 글 생성
-	public Post create(PostRequestDto dto, Long userId) {	
-	    User user = userRepository.findById(userId)
-	            .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
-
-	    // 3. recruitCount 직접 증가 
-	    int currentRecruitCount = user.getRecruitCount(); 
-	    user.setRecruitCount(currentRecruitCount + 1);    
-	    userRepository.save(user);
-
-	    // 4. Post 생성 및 user 연결
-	    Post post = dto.toEntity();
-	    post.setUser(user);
-		
-		return postRepository.save(post);
+	public Post create(PostRequestDto dto, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		User currentUser = userDetails.getUser();
+		return postRepository.save(dto.toEntity(currentUser));
 	}
 	
 	// 모집 글 상세 조회
@@ -121,4 +112,22 @@ public class PostService {
 	    }	
 		return new PostInfoResponseDto(post, currentParticipantsCount, isBookmarked);
 	}
+	
+	@Transactional(readOnly = true)
+	public GetMyPosts getMyPosts(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		User currentUser = userDetails.getUser();
+	    System.out.println("currentUser = " + currentUser.getId());
+        List<Post> posts = postRepository.findByUserIdOrderByCreatedAtDesc(currentUser.getId());
+        System.out.println("posts = " + posts);
+        List<GetMyPost> myPosts = posts.stream()
+            .map(post -> new GetMyPost(
+                    post.getTitle(),
+                    post.getDate(),
+                    participationRepository.countByPostId(post.getId()),
+                    post.getMaxPeople(),
+                    post.getStatus().name()
+            ))
+            .collect(Collectors.toList());
+        return GetMyPosts.of(myPosts);
+    }
 }

--- a/src/main/java/com/matchFit/user/security/CustomUserDetails.java
+++ b/src/main/java/com/matchFit/user/security/CustomUserDetails.java
@@ -1,0 +1,42 @@
+package com.matchFit.user.security;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.matchFit.user.entity.User;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/matchFit/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/matchFit/user/service/CustomUserDetailsService.java
@@ -1,9 +1,6 @@
 package com.matchFit.user.service;
 
-import java.util.Collections;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -11,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.matchFit.user.entity.User;
 import com.matchFit.user.repository.UserRepository;
+import com.matchFit.user.security.CustomUserDetails;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -23,11 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException("이메일 없음"));
 
-        return new org.springframework.security.core.userdetails.User(
-            user.getEmail(),
-            user.getPassword(),
-            Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
-        );
+        return new CustomUserDetails(user);
     }
 }
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/posts-get-applied

### 🔑 주요 변경사항
- 등록한 모집글 목록 조회 API 구현
- 등록 모집글에 신청자 목록 조회 API 구현
  - http://localhost:8080/api/posts/2/applicants

### 테스트 절차
1. 로그인한 사용자로 모집글 생성.
2. http://localhost:8080/api/posts/mine -> 내 모집글 확인 (toekn값 체크)
3. INSERT INTO participation (post_id, user_id, status, follow, created_at, updated_at)
VALUES (1, 1, 1, false, NOW(), NOW());
-> 참여신청 더미데이터 생성
4. http://localhost:8080/api/posts/1/applicants -> 신청자 확인


### 관련 이슈
- https://github.com/CLD-3rd/Final-Team3/issues/20
