### PR TITLE
Feat: 모집글 리스트 조회 인기순/가까운순 필터링 기능으로 변경

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,8 @@ services:
     restart: always
     volumes:
       - redis_insight_volume_data:/db
-    network_mode: "host"
+    ports: 
+      - 5540:5540
 
   mysql:
     image: mysql:8.0

--- a/src/main/java/com/matchFit/common/config/RedisConfig.java
+++ b/src/main/java/com/matchFit/common/config/RedisConfig.java
@@ -1,0 +1,53 @@
+package com.matchFit.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+	
+	@Value("${spring.data.redis.host}")
+    private String host;
+    
+    @Value("${spring.data.redis.port}")
+    private int port;
+    
+    @Value("${spring.data.redis.password}") 
+    String password;
+    
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+    	RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        
+        // 직렬화
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        
+        return template;
+    }
+    
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate template = new StringRedisTemplate();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}
+

--- a/src/main/java/com/matchFit/common/config/RedisListenerConfig.java
+++ b/src/main/java/com/matchFit/common/config/RedisListenerConfig.java
@@ -64,7 +64,7 @@ public class RedisListenerConfig {
         private final PostViewService postViewService;
         // view:{postId}:user:{userId} 패턴에서 postId, userId 추출
         private static final Pattern EXPIRED_VIEW_KEY =
-            Pattern.compile("^view:(\\d+):user:(\\d+)$");
+            Pattern.compile("^view:post_(\\d+):user_(\\d+)$");
 
         public ExpiredKeyListener(PostViewService postViewService) {
             this.postViewService = postViewService;

--- a/src/main/java/com/matchFit/common/config/RedisListenerConfig.java
+++ b/src/main/java/com/matchFit/common/config/RedisListenerConfig.java
@@ -1,0 +1,86 @@
+package com.matchFit.common.config;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import com.matchFit.post.service.PostViewService;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisListenerConfig {
+	
+	private final RedisConnectionFactory connectionFactory;
+	
+    @Bean
+    public RedisMessageListenerContainer redisContainer(
+            LettuceConnectionFactory connectionFactory,
+            ExpiredKeyListener expiredKeyListener) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        // "__keyevent@0__:expired" 은 DB 0번에서 만료 이벤트를 구독
+        container.addMessageListener(
+            expiredKeyListener,
+            new PatternTopic("__keyevent@0__:expired")
+        );
+        return container;
+    }
+
+    @Bean
+    public ExpiredKeyListener expiredKeyListener(PostViewService postViewService) {
+        return new ExpiredKeyListener(postViewService);
+    }
+    
+    @PostConstruct
+    public void enableKeyspaceNotifications() {
+        RedisConnection conn = null;
+        try {
+            conn = connectionFactory.getConnection();
+            // 'Ex' : E = Keyevent, x = expired 이벤트
+            conn.setConfig("notify-keyspace-events", "Ex");
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+    
+    private class ExpiredKeyListener implements MessageListener {
+        private final PostViewService postViewService;
+        // view:{postId}:user:{userId} 패턴에서 postId, userId 추출
+        private static final Pattern EXPIRED_VIEW_KEY =
+            Pattern.compile("^view:(\\d+):user:(\\d+)$");
+
+        public ExpiredKeyListener(PostViewService postViewService) {
+            this.postViewService = postViewService;
+        }
+
+        @Override
+        public void onMessage(Message message, byte[] pattern) {
+            String expiredKey = message.toString();
+            Matcher m = EXPIRED_VIEW_KEY.matcher(expiredKey);
+            if (m.matches()) {
+                Long postId = Long.valueOf(m.group(1));
+                // Long userId = Long.valueOf(m.group(2)); // 필요 없으면 생략
+                // 만료됐으니 ZSet 점수 1 차감
+                postViewService.decrementViewCount(postId);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/matchFit/post/controller/PostController.java
+++ b/src/main/java/com/matchFit/post/controller/PostController.java
@@ -24,6 +24,7 @@ import com.matchFit.post.dto.response.GetMyPostApplicants;
 import com.matchFit.post.dto.response.GetMyPosts;
 import com.matchFit.post.dto.response.GetPostsCalender;
 import com.matchFit.post.dto.response.GetPostsList;
+import com.matchFit.post.entity.SortType;
 import com.matchFit.post.entity.Sports;
 import com.matchFit.post.service.PostService;
 import com.matchFit.user.entity.Gender;
@@ -84,11 +85,11 @@ public class PostController {
     public ResponseEntity<GetPostsList> getPostsList(
 		@RequestParam(required = false) Sports sports,
         @RequestParam(required = false) Gender gender,
-        @RequestParam(required = false, defaultValue = "false") boolean nearest,
-        @RequestParam(required = true)
+        @RequestParam(required = false, defaultValue = "DATE") SortType sortType,
+        @RequestParam(required = false)
 	    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        GetPostsList postsList = postService.findByFilters(sports, gender, nearest, date);
+        GetPostsList postsList = postService.findByFilters(sports, gender, sortType, date);
         return ResponseEntity.ok(postsList);
     }
 	

--- a/src/main/java/com/matchFit/post/dto/response/GetPost.java
+++ b/src/main/java/com/matchFit/post/dto/response/GetPost.java
@@ -1,6 +1,8 @@
 package com.matchFit.post.dto.response;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.matchFit.post.entity.Post;
 
@@ -19,18 +21,21 @@ public class GetPost {
     private String town;
     private Integer maxPeople;
     private String gender;
+    private Long viewCount; // 게시글 조회수
 
-	public static List<GetPost> from(List<Post> posts) {
+	public static List<GetPost> from(List<Post> posts, Map<Long, Long> viewCounts) {
 		return posts.stream()
-			.map(post -> new GetPost(
-				post.getTitle(), 
-				post.getSports().getLabel(), 
-				post.getDate().toString(),
-				post.getStatus().getLabel(), 
-				post.getTown().getLabel(), 
-				post.getMaxPeople(), 
-				post.getGender().getLabel()))
-				.toList();
+	            .map(post -> new GetPost(
+	                post.getTitle(),
+	                post.getSports().getLabel(),
+	                post.getDate().toString(),
+	                post.getStatus().getLabel(),
+	                post.getTown().getLabel(),
+	                post.getMaxPeople(),
+	                post.getGender().getLabel(),
+	                viewCounts.getOrDefault(post.getId(), 0L)
+	            ))
+	            .collect(Collectors.toList());
 		}
 
 }

--- a/src/main/java/com/matchFit/post/entity/SortType.java
+++ b/src/main/java/com/matchFit/post/entity/SortType.java
@@ -1,0 +1,6 @@
+package com.matchFit.post.entity;
+
+public enum SortType {
+	DATE,      // 일정 가까운 순
+    POPULAR    // 인기순
+}

--- a/src/main/java/com/matchFit/post/repository/PostRepository.java
+++ b/src/main/java/com/matchFit/post/repository/PostRepository.java
@@ -18,17 +18,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	         WHERE (:sports IS NULL OR p.sports = :sports)
 	           AND (:gender IS NULL OR p.gender = :gender)
 	           AND (:date IS NULL OR DATE(p.date) = :date)
-	         ORDER BY
-	           CASE WHEN :nearest = true
-	                THEN ABS(TIMESTAMPDIFF(SECOND, p.date, NOW()))
-	                ELSE UNIX_TIMESTAMP(p.created_at)
-	           END
 	        """,
 	        nativeQuery = true)
 	    List<Post> findByFilters(
 	        @Param("sports") String sports,
 	        @Param("gender") String gender,
-	        @Param("nearest") boolean nearest,
 	        @Param("date") LocalDate date
 	    );
 

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -43,7 +43,7 @@ public class PostService {
 
 	private final ParticipationRepository participationRepository;
     private final PostRepository postRepository;
-//    private final UserRepository userRepository;
+    private final PostViewService postViewService;
 
     public GetPostsList findByFilters(Sports sports, Gender gender, SortType sortType, LocalDate date) {
     	List<Post> posts = postRepository.findByFilters(
@@ -52,26 +52,29 @@ public class PostService {
             date
         );
     	
+    	// 1) ID 리스트 수집
+    	List<Long> ids = posts.stream()
+                .map(Post::getId)
+                .collect(Collectors.toList());
+    	
+    	// 2) 조회수 맵 조회
+        Map<Long, Long> counts = postViewService.getViewCounts(ids);
+    	
     	if (sortType == SortType.DATE) {
            posts = sortPostsByDate(posts, sortType);
-        } else {
+           System.out.println("datePosts = " + posts);
+    	} else if (sortType == SortType.POPULAR) {
+           posts = sortPostsByPopularity(posts, counts);
+           System.out.println("popularPosts = " + posts);
+    	} else {
             throw new IllegalArgumentException("Unsupported sort type: " + sortType);
         }
         
-		List<GetPost> postDtos = GetPost.from(posts);
+		List<GetPost> postDtos = GetPost.from(posts, counts);
 
         return GetPostsList.of(postDtos);
     }
 
-	private List<Post> sortPostsByDate(List<Post> posts, SortType sortType) {
-		return posts.stream()
-                .sorted(Comparator.comparing(
-                    p -> Math.abs(
-                        ChronoUnit.SECONDS.between(p.getDate(), LocalDateTime.now())
-                    )
-                ))
-                .collect(Collectors.toList());
-	}
 
 	public GetPostsCalender findByMonth(YearMonth month) {
 		LocalDate startDate = month.atDay(1);
@@ -121,6 +124,7 @@ public class PostService {
 			post.setStatus(Status.CLOSED);
 			postRepository.save(post);
 		}
+		postViewService.recordView(postId, userId);
 		
 		boolean isBookmarked = false; 
 	    if (userId != null) {
@@ -145,5 +149,25 @@ public class PostService {
             ))
             .collect(Collectors.toList());
         return GetMyPosts.of(myPosts);
+    }
+	
+	
+	private List<Post> sortPostsByDate(List<Post> posts, SortType sortType) {
+		return posts.stream()
+                .sorted(Comparator.comparing(
+                    p -> Math.abs(
+                        ChronoUnit.SECONDS.between(p.getDate(), LocalDateTime.now())
+                    )
+                ))
+                .collect(Collectors.toList());
+	}
+	
+	private List<Post> sortPostsByPopularity(List<Post> posts, Map<Long, Long> counts) {
+        // 3) 조회수 내림차순 정렬
+        return posts.stream()
+                    .sorted(Comparator.comparingLong(
+                        p -> counts.getOrDefault(((Post) p).getId(), 0L)
+                    ).reversed())
+                    .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -1,8 +1,10 @@
 package com.matchFit.post.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -23,12 +25,12 @@ import com.matchFit.post.dto.response.GetPostCalender;
 import com.matchFit.post.dto.response.GetPostsCalender;
 import com.matchFit.post.dto.response.GetPostsList;
 import com.matchFit.post.entity.Post;
+import com.matchFit.post.entity.SortType;
 import com.matchFit.post.entity.Sports;
 import com.matchFit.post.entity.Status;
 import com.matchFit.post.repository.PostRepository;
 import com.matchFit.user.entity.Gender;
 import com.matchFit.user.entity.User;
-import com.matchFit.user.repository.UserRepository;
 import com.matchFit.user.security.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
@@ -41,21 +43,35 @@ public class PostService {
 
 	private final ParticipationRepository participationRepository;
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
+//    private final UserRepository userRepository;
 
-    public GetPostsList findByFilters(Sports sports, Gender gender, boolean nearest, LocalDate date) {
-        
-        List<Post> posts = postRepository.findByFilters(
+    public GetPostsList findByFilters(Sports sports, Gender gender, SortType sortType, LocalDate date) {
+    	List<Post> posts = postRepository.findByFilters(
             sports != null ? sports.name() : null, 
             gender != null ? gender.name() : null, 
-            nearest,
             date
         );
+    	
+    	if (sortType == SortType.DATE) {
+           posts = sortPostsByDate(posts, sortType);
+        } else {
+            throw new IllegalArgumentException("Unsupported sort type: " + sortType);
+        }
         
 		List<GetPost> postDtos = GetPost.from(posts);
 
         return GetPostsList.of(postDtos);
     }
+
+	private List<Post> sortPostsByDate(List<Post> posts, SortType sortType) {
+		return posts.stream()
+                .sorted(Comparator.comparing(
+                    p -> Math.abs(
+                        ChronoUnit.SECONDS.between(p.getDate(), LocalDateTime.now())
+                    )
+                ))
+                .collect(Collectors.toList());
+	}
 
 	public GetPostsCalender findByMonth(YearMonth month) {
 		LocalDate startDate = month.atDay(1);

--- a/src/main/java/com/matchFit/post/service/PostViewService.java
+++ b/src/main/java/com/matchFit/post/service/PostViewService.java
@@ -11,8 +11,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class PostViewService {
 	private static final Duration VIEW_TTL = Duration.ofMinutes(1);
-    private static final String VIEW_KEY_FMT = "view:%d:user:%d";
-    private static final String ZSET_KEY     = "post:views";
+	private static final String VIEW_KEY_FMT = "view:post_%d:user_%d";    // view:post:3:user:1
+	private static final String ZSET_KEY     = "views:posts:count";      // views:posts:count
+
 
     private final RedisTemplate<String,String> redis;
 

--- a/src/main/java/com/matchFit/post/service/PostViewService.java
+++ b/src/main/java/com/matchFit/post/service/PostViewService.java
@@ -1,0 +1,57 @@
+package com.matchFit.post.service;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostViewService {
+	private static final Duration VIEW_TTL = Duration.ofMinutes(1);
+    private static final String VIEW_KEY_FMT = "view:%d:user:%d";
+    private static final String ZSET_KEY     = "post:views";
+
+    private final RedisTemplate<String,String> redis;
+
+    public PostViewService(RedisTemplate<String,String> redis) {
+        this.redis = redis;
+    }
+
+    /**
+     * 사용자가 postId를 조회했을 때 호출.
+     * 10분 내에 중복 호출은 무시, 최초 호출일 때만 ZSET에 1 더함.
+     */
+    public void recordView(Long postId, Long userId) {
+        String viewKey = String.format(VIEW_KEY_FMT, postId, userId);
+
+        Boolean isNew = redis.opsForValue()
+            .setIfAbsent(viewKey, "1", VIEW_TTL);
+        if (Boolean.TRUE.equals(isNew)) {
+            // 최초 조회이므로 포스트 조회수 1 증가
+            redis.opsForZSet().incrementScore(ZSET_KEY, postId.toString(), 1);
+        }
+    }
+    
+    /** 만료될 때 호출해서 점수를 1 차감 */
+    public void decrementViewCount(Long postId) {
+        redis.opsForZSet().incrementScore(ZSET_KEY, postId.toString(), -1);
+    }
+
+    /**
+     * postId 리스트에 대해 각각 누적 조회수를 가져옴.
+     * 없으면 0 반환.
+     */
+    public Map<Long, Long> getViewCounts(Collection<Long> postIds) {
+        Map<Long, Long> result = new HashMap<>();
+        for (Long postId : postIds) {
+            // Redis ZSet 에서는 score(key, member) 가 단일 조회만 지원합니다.
+            Double score = redis.opsForZSet().score(ZSET_KEY, postId.toString());
+            long count = (score == null) ? 0L : score.longValue();
+            result.put(postId, count);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/posts-get-sort

### 🔑 주요 변경사항
- 조회 정렬 기준(인기순, 가까운순)에 따른 서비스 로직 분리
  - 최근 10분간 조회가 많은 인기모집글
- 게시물 조회수를 NoSQL에 저장

### 테스트 절차
2명의 유저, 3개 이상의 모집글 데이터 준비

## 가까운순
1. 모집글을 시간대별로 생성 (날짜를 다르게)
2. http://localhost:8080/api/posts/list?sortType=DATE 요청
3. 가까운순으로 정렬되는지 확인

## 인기순
1. docker-compose로 redis, redis-insight 실행
2.  http://localhost:5540 -> 접속 후 host, password값 properties에 있는값으로 입력
3. 2명의 각 유저로 1번 모집글 상세조회
4. 스크린샷처럼 값이 생기는지 확인
5. http://localhost:8080/api/posts/list?sortType=POPULAR -> 요청으로 응답에 조회수 및 인기순 정렬이 되는지 확인
6. 1분 후에 redis에 값이 없어지고, 조회를 했을 때, 조회수도 0으로 돌아가는지 확인 


### 🏞 스크린샷
<img width="670" height="328" alt="image" src="https://github.com/user-attachments/assets/6cf98031-6595-4eff-a1cd-c450d03faa5e" />

### 관련 이슈
- https://github.com/CLD-3rd/Final-Team3/issues/28
