### PR TITLE
Fix: 중복 요청 기능 수정

### DIFF
--- a/src/main/java/com/matchFit/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/matchFit/participation/repository/ParticipationRepository.java
@@ -20,4 +20,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 	
 	List<Participation> findAllByPostId(Long postId);
 
+	Participation findByPostIdAndUserId(Long postId, Long userId);
+
 }

--- a/src/main/java/com/matchFit/participation/service/ParticipationService.java
+++ b/src/main/java/com/matchFit/participation/service/ParticipationService.java
@@ -35,6 +35,10 @@ public class ParticipationService {
 		Post post = postRepository.findById(postId)
 				.orElseThrow(() -> new IllegalArgumentException("모집 글이 존재하지 않습니다"));
 		
+		// 이미 신청한 경우
+		if (participationRepository.findByPostIdAndUserId(postId, userId) != null) {
+			throw new IllegalStateException("이미 신청한 모집글입니다");
+		}
 		// 마감 체크
 		int currentPeople = participationRepository.countByPost_IdAndStatus(postId, ApplicationStatus.APPROVED);
 		

--- a/src/main/java/com/matchFit/post/controller/PostController.java
+++ b/src/main/java/com/matchFit/post/controller/PostController.java
@@ -73,12 +73,9 @@ public class PostController {
 		String email = userDetails.getUsername();
         Long userId = userService.findUserIdByEmail(email);
         
-        try {
-            participationService.applyPost(postId, userId);
-            return ResponseEntity.ok(new MessageResponse("신청 완료 되었습니다."));
-        } catch (IllegalStateException e) {
-            return ResponseEntity.ok(new MessageResponse("마감되었습니다"));
-        }
+        participationService.applyPost(postId, userId);
+        return ResponseEntity.ok(new MessageResponse("신청 완료 되었습니다."));
+
 	}
 	
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/post-apply-fix

### 🔑 주요 변경사항
- 모집글 중복 신청 방지 로직 구현
- 모집글 신청 실패 시, 예외처리하여 요청 실패로 처리 

### 테스트 절차
1. 최대 인원이 2 이상인 모집글에 모집 신청 (신청완료)
2. 한번 더 신청했을 때, 첫번째 스크린샷 로그 확인 
3. 해당 모집글에 APPROVED상태인 임의의 참여 데이터를 최대 인원에 맞게 Insert
4. 다시 신청했을 때, 두번째 스크린샷 로그 확인


### 🏞 스크린샷
<img width="368" height="27" alt="image" src="https://github.com/user-attachments/assets/691be7e4-0ba7-4c6d-82a9-ed9d38c56e9a" />
<img width="324" height="22" alt="image" src="https://github.com/user-attachments/assets/3af6db58-01d1-4f93-9353-f65cd939170a" />


### 관련 이슈
- https://github.com/CLD-3rd/Final-Team3/issues/34
