### PR TITLE
Fix: 현재 시점 이전 모집글 수정 방지

### DIFF
--- a/src/main/java/com/matchFit/common/BaseEntity.java
+++ b/src/main/java/com/matchFit/common/BaseEntity.java
@@ -5,12 +5,12 @@ import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-
+import lombok.Getter;
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/com/matchFit/post/controller/PostController.java
+++ b/src/main/java/com/matchFit/post/controller/PostController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +21,8 @@ import com.matchFit.participation.dto.response.MessageResponse;
 import com.matchFit.participation.service.ParticipationService;
 import com.matchFit.post.dto.PostInfoResponseDto;
 import com.matchFit.post.dto.PostRequestDto;
+import com.matchFit.post.dto.UpdatePostRequestDto;
+import com.matchFit.post.dto.UpdatePostResponseDto;
 import com.matchFit.post.dto.response.GetMyPostApplicants;
 import com.matchFit.post.dto.response.GetMyPosts;
 import com.matchFit.post.dto.response.GetPostsCalender;
@@ -114,6 +117,25 @@ public class PostController {
 	) {
 		GetMyPostApplicants applicants = participationService.getApplicantsByPost(postId, userDetails);
 	    return ResponseEntity.ok(applicants);
+	}
+	
+	
+	@PutMapping("/{postId}")
+	public ResponseEntity<?> updatePost(  
+	    @PathVariable Long postId,
+	    @RequestBody UpdatePostRequestDto request,  // 그대로 유지
+	    @AuthenticationPrincipal CustomUserDetails userDetails) {
+	    
+	    try {
+	        UpdatePostResponseDto response = postService.updatePost(postId, request, userDetails);
+	        return ResponseEntity.ok(response);
+	    } catch (IllegalStateException e) {
+	        // 날짜 지난 글 수정 시도
+	        return ResponseEntity.status(400).body(e.getMessage());
+	    } catch (IllegalArgumentException e) {
+	        // 존재하지 않는 글이나 권한 없음  
+	        return ResponseEntity.status(404).body(e.getMessage());
+	    }
 	}
 
 }

--- a/src/main/java/com/matchFit/post/dto/UpdatePostRequestDto.java
+++ b/src/main/java/com/matchFit/post/dto/UpdatePostRequestDto.java
@@ -1,0 +1,27 @@
+package com.matchFit.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.matchFit.post.entity.Sports;
+import com.matchFit.post.entity.Status;
+import com.matchFit.post.entity.Town;
+import com.matchFit.user.entity.Gender;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UpdatePostRequestDto {
+    private String title;
+    private String description;
+    private String location;
+    private LocalDateTime date;
+    private Integer maxPeople;
+    private Gender gender;
+    private Status status;
+    private Integer cost;
+    private String imageUrl;
+    private Sports sports;
+    private Town town;
+}

--- a/src/main/java/com/matchFit/post/dto/UpdatePostResponseDto.java
+++ b/src/main/java/com/matchFit/post/dto/UpdatePostResponseDto.java
@@ -1,0 +1,48 @@
+package com.matchFit.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.matchFit.post.entity.Post;
+import com.matchFit.post.entity.Sports;
+import com.matchFit.post.entity.Status;
+import com.matchFit.post.entity.Town;
+import com.matchFit.user.entity.Gender;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePostResponseDto {
+    private String title;
+    private String description;
+    private String location;
+    private LocalDateTime date;
+    private Integer maxPeople;
+    private Gender gender;
+    private Status status;
+    private Integer cost;
+    private String imageUrl;
+    private Sports sports;
+    private Town town;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    public static UpdatePostResponseDto from(Post post) {
+        return new UpdatePostResponseDto(
+            post.getTitle(),
+            post.getDescription(),
+            post.getLocation(),
+            post.getDate(),
+            post.getMaxPeople(),
+            post.getGender(),
+            post.getStatus(),
+            post.getCost(),
+            post.getImageUrl(),
+            post.getSports(),
+            post.getTown(),
+            post.getCreatedAt(),
+            post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -18,6 +18,8 @@ import com.matchFit.participation.entity.ApplicationStatus;
 import com.matchFit.participation.repository.ParticipationRepository;
 import com.matchFit.post.dto.PostInfoResponseDto;
 import com.matchFit.post.dto.PostRequestDto;
+import com.matchFit.post.dto.UpdatePostRequestDto;
+import com.matchFit.post.dto.UpdatePostResponseDto;
 import com.matchFit.post.dto.response.GetMyPost;
 import com.matchFit.post.dto.response.GetMyPosts;
 import com.matchFit.post.dto.response.GetPost;
@@ -170,4 +172,41 @@ public class PostService {
                     ).reversed())
                     .collect(Collectors.toList());
     }
+	
+	
+	@Transactional
+	public UpdatePostResponseDto updatePost(Long postId, UpdatePostRequestDto request, CustomUserDetails userDetails) {
+	    // 게시글 조회
+	    Post post = postRepository.findById(postId)
+	        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집글입니다."));
+	    
+	    // 작성자 권한 확인
+	    User currentUser = userDetails.getUser();
+	    if (!post.getUser().getId().equals(currentUser.getId())) {
+	        throw new IllegalArgumentException("본인이 작성한 글만 수정할 수 있습니다.");
+	    }
+	    
+	    // 날짜 확인
+	    LocalDateTime now = LocalDateTime.now();
+	    if (post.getDate().isBefore(now)) {
+	        throw new IllegalStateException("모임 날짜가 지난 글은 수정할 수 없습니다.");
+	    }
+	    
+	    // 게시글 정보 업데이트 (그대로)
+	    post.setTitle(request.getTitle());
+	    post.setDescription(request.getDescription());
+	    post.setLocation(request.getLocation());
+	    post.setDate(request.getDate());
+	    post.setMaxPeople(request.getMaxPeople());
+	    post.setGender(request.getGender());
+	    post.setStatus(request.getStatus());
+	    post.setCost(request.getCost());
+	    post.setImageUrl(request.getImageUrl());
+	    post.setSports(request.getSports());
+	    post.setTown(request.getTown());
+	    
+	    Post updatedPost = postRepository.save(post);
+	    
+	    return UpdatePostResponseDto.from(updatedPost);
+	}
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/post-put

### 🔑 주요 변경사항
- 모집글 정보 수정 API 구현
  - PUT http://localhost:8080/api/posts/{postId}
- 종료된 모집글 수정 시 400 Bad Request + "모임 날짜가 지난 글은 수정할 수 없습니다."

### 🏞 스크린샷
- 종료 전 모집글 수정
  <img width="1038" height="1086" alt="image" src="https://github.com/user-attachments/assets/63b694e8-d249-4b81-8438-7def4377b6bd" />

- 종료된 모집글 수정
  <img width="1059" height="761" alt="image" src="https://github.com/user-attachments/assets/eb4acc88-7957-45cd-bfec-096a9fe71d68" />


### 관련 이슈
- #40 
