### PR TITLE
Fix: 모집글 목록 조회 시, 지난 날짜는 보이지 않게 수정

### DIFF
--- a/src/main/java/com/matchFit/common/code/ErrorCode.java
+++ b/src/main/java/com/matchFit/common/code/ErrorCode.java
@@ -13,6 +13,9 @@ public enum ErrorCode {
 	POST_UNAUTHORIZED_USER("POST400", "게시글 작성 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
 	POST_PAST_EVENT_MODIFICATION("POST401", "과거 날짜에 게시글을 작성할 수 없습니다.", HttpStatus.BAD_REQUEST),
 	POST_NOT_FOUND("POST402", "존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
+	INVALID_SORTING_TYPE("POST403", "유효하지 않은 정렬 타입입니다.", HttpStatus.BAD_REQUEST),
+	POST_PAST_DAYS("POST404", "과거 날짜에 게시글을 조회할 수 없습니다.", HttpStatus.BAD_REQUEST),
+	POST_PAST_MONTHS("POST405", "과거 달에 게시글을 조회할 수 없습니다.", HttpStatus.BAD_REQUEST),
 	
 	
 	// USER

--- a/src/main/java/com/matchFit/common/code/SuccessCode.java
+++ b/src/main/java/com/matchFit/common/code/SuccessCode.java
@@ -22,8 +22,9 @@ public enum SuccessCode {
     USER_CREATED("USER200", "회원가입이 성공적으로 완료되었습니다."),
     USER_LOGIN_SUCCESS("USER201", "로그인에 성공했습니다."), 
     USER_EMAIL_AVAILABLE("USER202", "사용 가능한 이메일입니다."),
-    USER_NICKNAME_AVAILABLE("USER203", "사용 가능한 닉네임입니다.");
-	
+    USER_NICKNAME_AVAILABLE("USER203", "사용 가능한 닉네임입니다."),
+    USER_GET_MY_PROFILE("USER204", "사용자 프로필 정보를 성공적으로 조회했습니다."),
+	USER_EDIT_MY_PROFILE("USER205", "사용자 프로필 정보가 성공적으로 수정되었습니다.");	
 	
 	private final String code;
 	private final String message;

--- a/src/main/java/com/matchFit/post/exception/InvalidSortingTypeException.java
+++ b/src/main/java/com/matchFit/post/exception/InvalidSortingTypeException.java
@@ -1,0 +1,11 @@
+package com.matchFit.post.exception;
+
+import com.matchFit.common.code.ErrorCode;
+import com.matchFit.common.exception.GeneralException;
+
+public class InvalidSortingTypeException extends GeneralException {
+	public InvalidSortingTypeException() {
+		super(ErrorCode.INVALID_SORTING_TYPE);
+	}
+
+}

--- a/src/main/java/com/matchFit/post/exception/PastDayException.java
+++ b/src/main/java/com/matchFit/post/exception/PastDayException.java
@@ -1,0 +1,11 @@
+package com.matchFit.post.exception;
+
+import com.matchFit.common.code.ErrorCode;
+import com.matchFit.common.exception.GeneralException;
+
+public class PastDayException extends GeneralException {
+	
+	public PastDayException() {
+		super(ErrorCode.POST_PAST_DAYS);
+	}
+}

--- a/src/main/java/com/matchFit/post/exception/PastMonthException.java
+++ b/src/main/java/com/matchFit/post/exception/PastMonthException.java
@@ -1,0 +1,11 @@
+package com.matchFit.post.exception;
+
+import com.matchFit.common.code.ErrorCode;
+import com.matchFit.common.exception.GeneralException;
+
+public class PastMonthException extends GeneralException {
+
+	public PastMonthException() {
+		super(ErrorCode.POST_PAST_MONTHS);
+	}
+}

--- a/src/main/java/com/matchFit/post/repository/PostRepository.java
+++ b/src/main/java/com/matchFit/post/repository/PostRepository.java
@@ -17,7 +17,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	          FROM post p
 	         WHERE (:sports IS NULL OR p.sports = :sports)
 	           AND (:gender IS NULL OR p.gender = :gender)
-	           AND (:date IS NULL OR DATE(p.date) = :date)
+	           AND (
+				     :date IS NULL
+				     AND p.date > NOW()
+				   OR :date IS NOT NULL
+				     AND p.date >= :date
+				     AND p.date <  :date + INTERVAL '1' DAY
+				)
+	        ORDER BY p.date ASC
 	        """,
 	        nativeQuery = true)
 	    List<Post> findByFilters(

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -80,7 +80,17 @@ public class PostService {
 
 
 	public GetPostsCalender findByMonth(YearMonth month) {
-		LocalDate startDate = month.atDay(1);
+		YearMonth currentMonth = YearMonth.now();
+		if(month.isBefore(currentMonth)) {
+			throw new IllegalArgumentException("과거 달의 게시글은 조회할 수 없습니다.");
+		} 
+		LocalDate startDate;
+		// 이번 달(month)이면 오늘 날짜로, 아니면 해당 달의 1일로 설정
+	    if (YearMonth.from(LocalDate.now()).equals(month)) {
+	        startDate = LocalDate.now();
+	    } else {
+	        startDate = month.atDay(1);
+	    }
         LocalDate endDate = month.atEndOfMonth();
 
         List<Post> posts = postRepository.findAllByDateBetween(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -52,8 +52,10 @@ public class PostService {
 
     public GetPostsList findByFilters(Sports sports, Gender gender, SortType sortType, LocalDate date) {
     	// 이전 날짜값이 들어오면 예외 처리
-    	validateNotPastDate(date);
-    	
+    	if (date != null) {
+    	    validateNotPastDate(date);
+    	}
+
     	List<Post> posts = postRepository.findByFilters(
             sports != null ? sports.name() : null, 
             gender != null ? gender.name() : null, 

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -51,6 +51,9 @@ public class PostService {
     private final PostViewService postViewService;
 
     public GetPostsList findByFilters(Sports sports, Gender gender, SortType sortType, LocalDate date) {
+    	// 이전 날짜값이 들어오면 예외 처리
+    	validateNotPastDate(date);
+    	
     	List<Post> posts = postRepository.findByFilters(
             sports != null ? sports.name() : null, 
             gender != null ? gender.name() : null, 
@@ -202,6 +205,14 @@ public class PostService {
             throw new IllegalArgumentException("과거 달의 게시글은 조회할 수 없습니다.");
         }
     }
+	
+	private void validateNotPastDate(LocalDate date) {
+		LocalDate today = LocalDate.now();
+	    if (date.isBefore(today)) {
+	        throw new IllegalArgumentException("과거 날짜의 게시글은 조회할 수 없습니다.");
+	    }
+		
+	}
 
     private LocalDate determineStartDate(YearMonth month) {
         YearMonth current = YearMonth.from(LocalDate.now());

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -79,46 +79,21 @@ public class PostService {
     }
 
 
-	public GetPostsCalender findByMonth(YearMonth month) {
-		YearMonth currentMonth = YearMonth.now();
-		if(month.isBefore(currentMonth)) {
-			throw new IllegalArgumentException("과거 달의 게시글은 조회할 수 없습니다.");
-		} 
-		LocalDate startDate;
-		// 이번 달(month)이면 오늘 날짜로, 아니면 해당 달의 1일로 설정
-	    if (YearMonth.from(LocalDate.now()).equals(month)) {
-	        startDate = LocalDate.now();
-	    } else {
-	        startDate = month.atDay(1);
-	    }
-        LocalDate endDate = month.atEndOfMonth();
+    public GetPostsCalender findByMonth(YearMonth month) {
+        validateNotPastMonth(month);
 
-        List<Post> posts = postRepository.findAllByDateBetween(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
-        
-        // 3. 날짜별 → 종목별로 개수 집계
-        Map<LocalDate, Map<Sports, Long>> grouped = posts.stream()
-                .collect(Collectors.groupingBy(
-                    post -> post.getDate().toLocalDate(),
-                    Collectors.groupingBy(Post::getSports, Collectors.counting())
-                ));
-        
-        // 4. DTO(GetPostCalender) 리스트로 변환
-        List<GetPostCalender> calendarEntries = grouped.entrySet().stream()
-            .flatMap(dayEntry ->
-                dayEntry.getValue().entrySet().stream()
-                    .map(sportEntry -> new GetPostCalender(
-                        dayEntry.getKey().toString(),                       // "2025-07-13" 같은 day 문자열
-                        new GetPostCalender.Event(
-                            sportEntry.getKey().getLabel(),           // enum 한글명, ex. "축구"
-                            sportEntry.getValue().intValue()               // 해당 일자·종목 이벤트 개수
-                        )
-                    ))
-            )
-            .sorted(Comparator.comparing(GetPostCalender::getDay))           // day 오름차순 정렬
-            .collect(Collectors.toList());
-        // 5. 전체 결과를 GetPostsCalender로 감싸서 반환
+        LocalDate startDate = determineStartDate(month);
+        LocalDateTime fromDate = startDate.atStartOfDay();
+        LocalDateTime toDate   = month.atEndOfMonth().atTime(LocalTime.MAX);
+
+        List<Post> posts = postRepository.findAllByDateBetween(fromDate, toDate);
+        Map<LocalDate, Map<Sports, Long>> grouped = groupByDateAndSport(posts);
+        List<GetPostCalender> calendarEntries = toCalendarEntries(grouped);
+
         return GetPostsCalender.of(calendarEntries);
-	}
+    }
+
+    
 	
 	// 모집 글 생성
 	public Post create(PostRequestDto dto, @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -220,4 +195,43 @@ public class PostService {
 	    
 	    return UpdatePostResponseDto.from(updatedPost);
 	}
+	
+	private void validateNotPastMonth(YearMonth month) {
+        YearMonth currentMonth = YearMonth.now();
+        if (month.isBefore(currentMonth)) {
+            throw new IllegalArgumentException("과거 달의 게시글은 조회할 수 없습니다.");
+        }
+    }
+
+    private LocalDate determineStartDate(YearMonth month) {
+        YearMonth current = YearMonth.from(LocalDate.now());
+        if (month.equals(current)) {
+            return LocalDate.now();
+        }
+        return month.atDay(1);
+    }
+
+    private Map<LocalDate, Map<Sports, Long>> groupByDateAndSport(List<Post> posts) {
+        return posts.stream()
+            .collect(Collectors.groupingBy(
+                post -> post.getDate().toLocalDate(),
+                Collectors.groupingBy(Post::getSports, Collectors.counting())
+            ));
+    }
+
+    private List<GetPostCalender> toCalendarEntries(Map<LocalDate, Map<Sports, Long>> grouped) {
+        return grouped.entrySet().stream()
+            .flatMap(dayEntry ->
+                dayEntry.getValue().entrySet().stream()
+                    .map(sportEntry -> new GetPostCalender(
+                        dayEntry.getKey().toString(),
+                        new GetPostCalender.Event(
+                            sportEntry.getKey().getLabel(),
+                            sportEntry.getValue().intValue()
+                        )
+                    ))
+            )
+            .sorted(Comparator.comparing(GetPostCalender::getDay))
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -30,7 +30,10 @@ import com.matchFit.post.entity.Post;
 import com.matchFit.post.entity.SortType;
 import com.matchFit.post.entity.Sports;
 import com.matchFit.post.entity.Status;
+import com.matchFit.post.exception.InvalidSortingTypeException;
+import com.matchFit.post.exception.PastDayException;
 import com.matchFit.post.exception.PastEventModificationException;
+import com.matchFit.post.exception.PastMonthException;
 import com.matchFit.post.exception.PostNotFoundException;
 import com.matchFit.post.exception.UnauthorizedUserException;
 import com.matchFit.post.repository.PostRepository;
@@ -75,7 +78,7 @@ public class PostService {
     	} else if (sortType == SortType.POPULAR) {
            posts = sortPostsByPopularity(posts, counts);
     	} else {
-            throw new IllegalArgumentException("Unsupported sort type: " + sortType);
+            throw new InvalidSortingTypeException();
         }
         
 		List<GetPost> postDtos = GetPost.from(posts, counts);
@@ -204,14 +207,14 @@ public class PostService {
 	private void validateNotPastMonth(YearMonth month) {
         YearMonth currentMonth = YearMonth.now();
         if (month.isBefore(currentMonth)) {
-            throw new IllegalArgumentException("과거 달의 게시글은 조회할 수 없습니다.");
+            throw new PastMonthException();
         }
     }
 	
 	private void validateNotPastDate(LocalDate date) {
 		LocalDate today = LocalDate.now();
 	    if (date.isBefore(today)) {
-	        throw new IllegalArgumentException("과거 날짜의 게시글은 조회할 수 없습니다.");
+	        throw new PastDayException();
 	    }
 		
 	}

--- a/src/main/java/com/matchFit/user/controller/MyPageController.java
+++ b/src/main/java/com/matchFit/user/controller/MyPageController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.matchFit.common.code.SuccessCode;
+import com.matchFit.common.dto.response.ApiResponseDTO;
 import com.matchFit.user.dto.request.EditMyPageRequest;
 import com.matchFit.user.dto.response.MyPageResponse;
 import com.matchFit.user.security.CustomUserDetails;
@@ -22,20 +24,20 @@ public class MyPageController {
     private final MyPageService myPageService;
 
     @GetMapping
-    public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponseDTO<MyPageResponse>> getMyPage(@AuthenticationPrincipal CustomUserDetails userDetails) {
         String email = userDetails.getUsername(); 
         MyPageResponse response = myPageService.getMyPage(email);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponseDTO.onSuccess(SuccessCode.USER_GET_MY_PROFILE, response));
     }
 
     @PutMapping
-    public ResponseEntity<MyPageResponse> editMyPage(
+    public ResponseEntity<ApiResponseDTO<MyPageResponse>> editMyPage(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @RequestBody EditMyPageRequest request) {
         
         String email = userDetails.getUsername();
         MyPageResponse response = myPageService.editMyPage(email, request);
-        return ResponseEntity.ok(response);  
+        return ResponseEntity.ok(ApiResponseDTO.onSuccess(SuccessCode.USER_EDIT_MY_PROFILE, response));  
     }
 
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/posts-get-fix-date

### 🔑 주요 변경사항
- 모집글 리스트 조회 시, 이전 날짜 선택 시, 예외처리
- 모집글 리스트 조회 시, 날짜를 선택안했을 경우, 이전 날짜의 모집글은 조회되지 않도록 수정
- 모집글 캘린더 조회 시, 이전 달 선택 시, 예외처리
- 내 정보 조회, 내 정보 수정 응답 통일

### 테스트
1. 모집글 리스트 조회 시, 지난 날짜의 모집글이 안보이는지 확인 (날짜 선택 x) 
http://localhost:8080/api/posts/list
2. 모집글 리스트 조회 시, 지난 날짜 입력 후, 예외 처리 확인
http://localhost:8080/api/posts/list?date=2025-07-24
3. 모집글 캘린더 조회 시, 지난 달 입력 후, 예외 처리 확인
http://localhost:8080/api/posts/calender?month=2025-06

### 🏞 스크린샷
<img width="347" height="186" alt="image" src="https://github.com/user-attachments/assets/66f330cd-ccbd-4e54-ac33-374def6b44ff" />
<img width="355" height="191" alt="image" src="https://github.com/user-attachments/assets/9ef8f003-c8a7-4cf4-aece-a566205d71bd" />



### 관련 이슈
- https://github.com/CLD-3rd/Final-Team3/issues/39
