### PR TITLE
Feat: Follow 테이블 생성 및 찜 기능 구현

### DIFF
--- a/src/main/java/com/matchFit/common/code/SuccessCode.java
+++ b/src/main/java/com/matchFit/common/code/SuccessCode.java
@@ -25,9 +25,14 @@ public enum SuccessCode {
     USER_NICKNAME_AVAILABLE("USER203", "사용 가능한 닉네임입니다."),
     USER_GET_MY_PROFILE("USER204", "사용자 프로필 정보를 성공적으로 조회했습니다."),
 	USER_EDIT_MY_PROFILE("USER205", "사용자 프로필 정보가 성공적으로 수정되었습니다."),
+	USER_GET_MY_FOLLOWS("USER206", "내가 찜한 모집글 리스트를 성공적으로 조회했습니다."),
+
 	
 	// PARTICIPATION
-	PARTICIPATION_MANAGED("PARTICIPATION200", "신청자 관리가 성공적으로 완료되었습니다.");
+	PARTICIPATION_MANAGED("PARTICIPATION200", "신청자 관리가 성공적으로 완료되었습니다."),
+	
+	// FOLLOW
+	FOLLOW_TOGGLED("FOLLOW200", "찜 상태가 성공적으로 변경되었습니다.");
 	
 	private final String code;
 	private final String message;

--- a/src/main/java/com/matchFit/follow/controller/FollowController.java
+++ b/src/main/java/com/matchFit/follow/controller/FollowController.java
@@ -1,0 +1,49 @@
+package com.matchFit.follow.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.matchFit.common.code.SuccessCode;
+import com.matchFit.common.dto.response.ApiResponseDTO;
+import com.matchFit.follow.dto.response.FollowApplyResponseDto;
+import com.matchFit.follow.dto.response.GetMyFollowResponseDto;
+import com.matchFit.follow.service.FollowService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+    
+    private final FollowService followService;
+    
+    // 팔로우 토글
+    @PostMapping("/api/posts/{postId}/follow")
+    public ResponseEntity<ApiResponseDTO<FollowApplyResponseDto>> toggleFollow(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        String email = userDetails.getUsername();
+        FollowApplyResponseDto result = followService.toggleFollow(email, postId);
+        
+        return ResponseEntity.ok(ApiResponseDTO.onSuccess(SuccessCode.FOLLOW_TOGGLED, result));
+    }
+    
+    // 내가 팔로우한 모집글 목록 조회
+    @GetMapping("/api/user/follow")
+    public ResponseEntity<ApiResponseDTO<List<GetMyFollowResponseDto>>> getMyFollows(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        
+        String email = userDetails.getUsername();
+        List<GetMyFollowResponseDto> follows = followService.getUserFollows(email);
+        
+        return ResponseEntity.ok(ApiResponseDTO.onSuccess(SuccessCode.USER_GET_MY_FOLLOWS, follows));
+    }
+}

--- a/src/main/java/com/matchFit/follow/dto/response/FollowApplyResponseDto.java
+++ b/src/main/java/com/matchFit/follow/dto/response/FollowApplyResponseDto.java
@@ -1,0 +1,11 @@
+package com.matchFit.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowApplyResponseDto {
+    Long postId;
+    boolean isFollowed;
+}

--- a/src/main/java/com/matchFit/follow/dto/response/GetMyFollowResponseDto.java
+++ b/src/main/java/com/matchFit/follow/dto/response/GetMyFollowResponseDto.java
@@ -1,0 +1,21 @@
+package com.matchFit.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetMyFollowResponseDto {
+    private Long postId;
+    private String title;
+    private String sports;          
+    private String location;        
+    private String date;            
+    private int currentPeople;    
+    private int maxPeople;        
+    private String followedAt;      
+    private Integer cost;          
+    private String status;         
+}

--- a/src/main/java/com/matchFit/follow/entity/Follow.java
+++ b/src/main/java/com/matchFit/follow/entity/Follow.java
@@ -1,0 +1,41 @@
+package com.matchFit.follow.entity;
+
+import com.matchFit.post.entity.Post;
+import com.matchFit.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "follow", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"userId", "postId"})
+})
+public class Follow {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "postId", nullable = false)
+    private Post post;
+    
+    public Follow(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/matchFit/follow/entity/Follow.java
+++ b/src/main/java/com/matchFit/follow/entity/Follow.java
@@ -1,5 +1,6 @@
 package com.matchFit.follow.entity;
 
+import com.matchFit.common.entity.BaseEntity;
 import com.matchFit.post.entity.Post;
 import com.matchFit.user.entity.User;
 import jakarta.persistence.Entity;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "follow", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"userId", "postId"})
 })
-public class Follow {
+public class Follow extends BaseEntity {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/matchFit/follow/repository/FollowRepository.java
+++ b/src/main/java/com/matchFit/follow/repository/FollowRepository.java
@@ -1,0 +1,23 @@
+package com.matchFit.follow.repository;
+
+import com.matchFit.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    
+    // 내 모든 팔로우 조회
+    @Query("SELECT f FROM Follow f JOIN FETCH f.post WHERE f.user.id = :userId")
+    List<Follow> findByUserIdWithPost(@Param("userId") Long userId);
+    
+    // 게시글의 팔로우 개수
+    long countByPostId(Long postId);
+    
+    // 팔로우 상태 확인 
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+    
+    // 팔로우 삭제 
+    void deleteByUserIdAndPostId(Long userId, Long postId);
+}

--- a/src/main/java/com/matchFit/follow/service/FollowService.java
+++ b/src/main/java/com/matchFit/follow/service/FollowService.java
@@ -1,0 +1,101 @@
+package com.matchFit.follow.service;
+
+import com.matchFit.post.entity.Post;
+import com.matchFit.post.repository.PostRepository;
+import com.matchFit.user.entity.User;
+import com.matchFit.user.repository.UserRepository;
+import com.matchFit.follow.entity.Follow;
+import com.matchFit.follow.repository.FollowRepository;
+import com.matchFit.follow.dto.response.FollowApplyResponseDto;
+import com.matchFit.follow.dto.response.GetMyFollowResponseDto;
+import com.matchFit.participation.repository.ParticipationRepository;
+import com.matchFit.participation.entity.ApplicationStatus;
+import com.matchFit.common.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FollowService {
+    
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final ParticipationRepository participationRepository;
+    
+    // 팔로우 토글 (ErrorCode 사용)
+    public FollowApplyResponseDto toggleFollow(String email, Long postId) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+        
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.POST_NOT_FOUND.getMessage()));
+        
+        Long userId = user.getId();
+        boolean isCurrentlyFollowed = followRepository.existsByUserIdAndPostId(userId, postId);
+        
+        if (isCurrentlyFollowed) {
+            // 팔로우시 팔로우 해제
+            followRepository.deleteByUserIdAndPostId(userId, postId);
+        } else {
+            // 팔로우 안돼있을 시 팔로우 추가
+            Follow follow = new Follow(user, post);
+            followRepository.save(follow);
+        }
+        
+        boolean isFollowed = !isCurrentlyFollowed;
+        
+        return new FollowApplyResponseDto(postId, isFollowed);
+    }
+    
+    // 사용자의 팔로우 목록 조회 
+    @Transactional(readOnly = true)
+    public List<GetMyFollowResponseDto> getUserFollows(String email) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+        
+        List<Follow> follows = followRepository.findByUserIdWithPost(user.getId());
+        
+        return follows.stream()
+            .map(follow -> {
+                Post post = follow.getPost();
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+                DateTimeFormatter followedAtFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                
+                // 실제 승인된 사용자 수 계산
+                int currentPeople = participationRepository.countByPost_IdAndStatus(post.getId(), ApplicationStatus.APPROVED);
+                
+                return new GetMyFollowResponseDto(
+                    post.getId(),
+                    post.getTitle(),
+                    post.getSports().toString(),        
+                    post.getLocation(),                 
+                    post.getDate().format(formatter),  
+                    currentPeople,                      
+                    post.getMaxPeople(),              
+                    follow.getCreatedAt() != null ? 
+                        follow.getCreatedAt().format(followedAtFormatter) : null, // 찜한 날짜
+                    post.getCost(),                   
+                    post.getStatus().toString()        
+                );
+            })
+            .collect(Collectors.toList());
+    }
+    
+    // 팔로우 상태 확인
+    @Transactional(readOnly = true)
+    public boolean isFollowed(Long userId, Long postId) {
+        return followRepository.existsByUserIdAndPostId(userId, postId);
+    }
+    
+    // 게시글의 팔로우 개수 
+    @Transactional(readOnly = true)
+    public long getFollowCount(Long postId) {
+        return followRepository.countByPostId(postId);
+    }
+}

--- a/src/main/java/com/matchFit/participation/entity/Participation.java
+++ b/src/main/java/com/matchFit/participation/entity/Participation.java
@@ -34,9 +34,7 @@ public class Participation extends BaseEntity {
 	// 신청 상태의 status, 모집 상태의 status랑 구분
 	@Enumerated(EnumType.STRING)
 	private ApplicationStatus status;
-	
-	private boolean follow;
-	
+		
 	protected Participation() {}
 	
 	public Participation(User user, Post post) {

--- a/src/main/java/com/matchFit/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/matchFit/participation/repository/ParticipationRepository.java
@@ -13,9 +13,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 	// 현재 신청자 수 계산
 	int countByPostId(Long postId);
 	
-	// 사용자의 찜 여부 확인
-	boolean existsByPostIdAndUserIdAndFollowTrue(Long postId, Long userId);
-	
 	// 신청 승인된 사용자만 count
 	int countByPost_IdAndStatus(Long postId, ApplicationStatus status);
 	

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.matchFit.follow.repository.FollowRepository;
 import com.matchFit.participation.entity.ApplicationStatus;
 import com.matchFit.participation.repository.ParticipationRepository;
 import com.matchFit.post.dto.PostInfoResponseDto;
@@ -48,7 +49,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PostService {
-
+	private final FollowRepository followRepository;
 	private final ParticipationRepository participationRepository;
     private final PostRepository postRepository;
     private final PostViewService postViewService;
@@ -124,7 +125,7 @@ public class PostService {
 		
 		boolean isBookmarked = false; 
 	    if (userId != null) {
-	        isBookmarked = participationRepository.existsByPostIdAndUserIdAndFollowTrue(postId, userId);
+	    	isBookmarked = followRepository.existsByUserIdAndPostId(userId, postId);
 	    }	
 		return new PostInfoResponseDto(post, currentParticipantsCount, isBookmarked);
 	}
@@ -137,10 +138,10 @@ public class PostService {
         System.out.println("posts = " + posts);
         List<GetMyPost> myPosts = posts.stream()
             .map(post -> new GetMyPost(
+            		post.getId(), 
                     post.getTitle(),
                     post.getDate(),
-                    participationRepository.countByPostId(post.getId()),
-                    post.getMaxPeople(),
+                    participationRepository.countByPost_IdAndStatus(post.getId(),ApplicationStatus.APPROVED),                    post.getMaxPeople(),
                     post.getStatus().name()
             ))
             .collect(Collectors.toList());
@@ -186,7 +187,7 @@ public class PostService {
 	        throw new PastEventModificationException();
 	    }
 	    
-	    // 게시글 정보 업데이트 (그대로)
+	    // 게시글 정보 업데이트
 	    post.setTitle(request.getTitle());
 	    post.setDescription(request.getDescription());
 	    post.setLocation(request.getLocation());


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/follow
</br>

### 🔑 주요 변경사항
- Participation 테이블에서 follow 컬럼 제거
- Follow 테이블 생성
- 찜 신청/취소 API
  - POST http://localhost:8080/api/posts/{postId}/follow
  - 찜 된 상태 → 찜 취소, 찜 안된 상태 → 찜
  
- 찜한 모집글 조회 API
  - GET http://localhost:8080/api/user/follow
</br>

### 🏞 스크린샷
- 찜 신청/취소
  <img width="1307" height="569" alt="image" src="https://github.com/user-attachments/assets/55ab3d44-5d90-41b8-a2a2-ad4d69f63bd7" />


- 찜한 모집글 조회
  <img width="1129" height="839" alt="image" src="https://github.com/user-attachments/assets/74af380c-2da9-4fdf-896d-fbe7e6b78c96" />


### 관련 이슈
- #54 
