### PR TITLE
Refactoring: 모집글 조회 시, 현재 인원에 대한 정보 캐싱 처리

### DIFF
--- a/src/main/java/com/matchFit/participation/service/ParticipationService.java
+++ b/src/main/java/com/matchFit/participation/service/ParticipationService.java
@@ -1,5 +1,6 @@
 package com.matchFit.participation.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,9 +31,11 @@ import com.matchFit.user.repository.UserRepository;
 import com.matchFit.user.security.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ParticipationService {
    
    private final ParticipationRepository participationRepository;
@@ -41,6 +44,7 @@ public class ParticipationService {
    private final StringRedisTemplate redisTemplate;
    
    private static final String APPLICANT_KEY_FMT = "applicants:post_%d";
+   private static final Integer APPLICANT_KEY_TTL_MINIUTES = 5;
 
    private String getApplicantKey(Long postId) {
        return String.format(APPLICANT_KEY_FMT, postId);
@@ -182,48 +186,46 @@ public class ParticipationService {
         ApplicationStatus previous = participation.getStatus();
 
         if (dto.getDecision() == Decision.ACCEPT) {
+            // 이미 승인된 경우 중복 승인 방지
             if (previous == ApplicationStatus.APPROVED) {
-                return new DecisionApplicant(participation.getUser().getId(),
-                        participation.getUser().getNickname(), participation.getStatus());
+                return new DecisionApplicant(
+                        participation.getUser().getId(),
+                        participation.getUser().getNickname(),
+                        participation.getStatus()
+                );
             }
 
+            // DB에 승인 반영
             participation.setStatus(ApplicationStatus.APPROVED);
             participationRepository.saveAndFlush(participation);
 
+            // Redis: 해당 포스트 키를 INCR (key가 없으면 안전하게 DB 기준으로 초기화)
             String key = getApplicantKey(postId);
             try {
-                // Redis에서 현재 승인 인원 수 증가
                 Long newCount = redisTemplate.opsForValue().increment(key, 1);
                 if (newCount == null) {
-                    // Redis 초기화: DB 기준으로 현재 승인 인원 수 세팅
-                    long dbCount = participationRepository.countByPost_IdAndStatus(postId, ApplicationStatus.APPROVED);
-                    redisTemplate.opsForValue().set(key, String.valueOf(dbCount));
-                    newCount = dbCount;
+                    // Redis가 비어 있거나 이상한 경우 DB에서 집계하여 초기화 (DB count는 APPROVED 수 -> 작성자 포함하려면 +1)
+                    long approvedCount = participationRepository.countByPost_IdAndStatus(postId, ApplicationStatus.APPROVED);
+                    long totalIncludingAuthor = approvedCount + 1; // 작성자 포함
+                    redisTemplate.opsForValue().set(key, String.valueOf(totalIncludingAuthor), Duration.ofMinutes(APPLICANT_KEY_TTL_MINIUTES));
+                    newCount = totalIncludingAuthor;
                 }
 
-                // 모집 마감 체크
+                // 모집 마감 체크 (Redis 기준)
                 if (newCount >= post.getMaxPeople() && post.getStatus() != Status.CLOSED) {
                     post.setStatus(Status.CLOSED);
                     postRepository.save(post);
                 }
-
             } catch (Exception e) {
-                System.out.println("Redis update failed for post {}: {}" + postId + e.getMessage() + e);
+                // Redis 실패는 DB 반영에 영향주지 않음 — 로그만 남기고 진행
+               log.error("Redis update failed for post {}: {}", postId, e.getMessage(), e);
             }
 
-        } else { // REJECT
+        } else { // REJECT: DB만 업데이트, Redis는 건드리지 않음
             participation.setStatus(ApplicationStatus.REJECTED);
             participationRepository.saveAndFlush(participation);
 
-            // 이전 상태가 APPROVED였다면 Redis에서 DECR
-            if (previous == ApplicationStatus.APPROVED) {
-                String key = getApplicantKey(postId);
-                try {
-                    redisTemplate.opsForValue().decrement(key);
-                } catch (Exception e) {
-                	System.out.println("Redis decrement failed for post {}: {}" + postId + e.getMessage() + e);
-                }
-            }
+            // 주의: 이전에 APPROVED였더라도 Redis에서 DECR 하지 않음(요청하신 대로)
         }
 
         return new DecisionApplicant(

--- a/src/main/java/com/matchFit/participation/service/ParticipationService.java
+++ b/src/main/java/com/matchFit/participation/service/ParticipationService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +38,14 @@ public class ParticipationService {
    private final ParticipationRepository participationRepository;
    private final UserRepository userRepository;
    private final PostRepository postRepository;
+   private final StringRedisTemplate redisTemplate;
+   
+   private static final String APPLICANT_KEY_FMT = "applicants:post_%d";
 
+   private String getApplicantKey(Long postId) {
+       return String.format(APPLICANT_KEY_FMT, postId);
+   }
+   
    // 모집 글 신청
    @Transactional
    public void applyPost(Long postId, Long userId) {
@@ -161,73 +169,67 @@ public class ParticipationService {
     }
 
     @Transactional
-   public DecisionApplicant manageApplicant(Long postId, ManageApplicant dto, CustomUserDetails userDetails) {
-      Post post = postRepository.findById(postId).orElseThrow(
-            () -> new PostNotFoundException());
-
-      User currentUser = userDetails.getUser();
-
-      if (!post.getUser().getId().equals(currentUser.getId())) {
-         throw new UnauthorizedUserException();
-      }
+    public DecisionApplicant manageApplicant(Long postId, ManageApplicant dto, CustomUserDetails userDetails) {
+        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+        User currentUser = userDetails.getUser();
+        if (!post.getUser().getId().equals(currentUser.getId())) {
+            throw new UnauthorizedUserException();
+        }
 
         Participation participation = participationRepository
-            .findByPostIdAndUserId(postId, dto.getApplicantId());
+                .findByPostIdAndUserId(postId, dto.getApplicantId());
 
-//        if (dto.getDecision() == Decision.ACCEPT) {
-//            participation.setStatus(ApplicationStatus.APPROVED);
-//
-//            // 현재 승인된 인원 수 확인
-//            int approvedCount = participationRepository.countByPost_IdAndStatus(postId, ApplicationStatus.APPROVED);
-//
-//            // 승인 완료 처리로 인해 인원이 찼다면 마감 처리
-//            if (approvedCount + 1 >= post.getMaxPeople()) {
-//                post.setStatus(com.matchFit.post.entity.Status.CLOSED);
-//                postRepository.save(post);
-//                participationRepository.flush(); 
-//            }
-//
-//        } else {
-//            participation.setStatus(ApplicationStatus.REJECTED);
-//        }
-//      return new DecisionApplicant(
-//            participation.getUser().getId(),
-//            participation.getUser().getNickname(),
-//            participation.getStatus());
-      
+        ApplicationStatus previous = participation.getStatus();
+
         if (dto.getDecision() == Decision.ACCEPT) {
-          // 이미 승인된 경우 중복 승인 방지
-          if (participation.getStatus() == ApplicationStatus.APPROVED) {
-              return new DecisionApplicant(
-                      participation.getUser().getId(),
-                      participation.getUser().getNickname(),
-                      participation.getStatus()
-              );
-          }
+            if (previous == ApplicationStatus.APPROVED) {
+                return new DecisionApplicant(participation.getUser().getId(),
+                        participation.getUser().getNickname(), participation.getStatus());
+            }
 
-          participation.setStatus(ApplicationStatus.APPROVED);
-          participationRepository.saveAndFlush(participation); // 변경을 DB에 먼저 반영
+            participation.setStatus(ApplicationStatus.APPROVED);
+            participationRepository.saveAndFlush(participation);
 
-          // 승인 인원 재집계 (이번 승인자 포함됨)
-          int approvedCount = participationRepository
-                  .countByPost_IdAndStatus(postId, ApplicationStatus.APPROVED)+1;
+            String key = getApplicantKey(postId);
+            try {
+                // Redis에서 현재 승인 인원 수 증가
+                Long newCount = redisTemplate.opsForValue().increment(key, 1);
+                if (newCount == null) {
+                    // Redis 초기화: DB 기준으로 현재 승인 인원 수 세팅
+                    long dbCount = participationRepository.countByPost_IdAndStatus(postId, ApplicationStatus.APPROVED);
+                    redisTemplate.opsForValue().set(key, String.valueOf(dbCount));
+                    newCount = dbCount;
+                }
 
-          if (approvedCount >= post.getMaxPeople()) {
-              if (post.getStatus() != com.matchFit.post.entity.Status.CLOSED) {
-                  post.setStatus(com.matchFit.post.entity.Status.CLOSED);
-                  postRepository.save(post);
-              }
-          }
-      } else {
-          participation.setStatus(ApplicationStatus.REJECTED);
-          participationRepository.save(participation);
-      }
+                // 모집 마감 체크
+                if (newCount >= post.getMaxPeople() && post.getStatus() != Status.CLOSED) {
+                    post.setStatus(Status.CLOSED);
+                    postRepository.save(post);
+                }
 
-      return new DecisionApplicant(
-              participation.getUser().getId(),
-              participation.getUser().getNickname(),
-              participation.getStatus()
-      );
-        
-   }
+            } catch (Exception e) {
+                System.out.println("Redis update failed for post {}: {}" + postId + e.getMessage() + e);
+            }
+
+        } else { // REJECT
+            participation.setStatus(ApplicationStatus.REJECTED);
+            participationRepository.saveAndFlush(participation);
+
+            // 이전 상태가 APPROVED였다면 Redis에서 DECR
+            if (previous == ApplicationStatus.APPROVED) {
+                String key = getApplicantKey(postId);
+                try {
+                    redisTemplate.opsForValue().decrement(key);
+                } catch (Exception e) {
+                	System.out.println("Redis decrement failed for post {}: {}" + postId + e.getMessage() + e);
+                }
+            }
+        }
+
+        return new DecisionApplicant(
+                participation.getUser().getId(),
+                participation.getUser().getNickname(),
+                participation.getStatus()
+        );
+    }
 }

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -1,19 +1,24 @@
 package com.matchFit.post.service;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
@@ -67,6 +72,10 @@ public class PostService {
     private final PostViewService postViewService;
     private final S3Service s3Service;
     private final ShortWeatherService weatherService;
+    private final StringRedisTemplate redisTemplate;
+    
+    private static final String APPLICANT_KEY_FMT = "applicants:post_%d";
+    private static final Integer APPLICANT_KEY_TTL_MINIUTES = 5;
     
     public GetPostsList findByFilters(Sports sports, Gender gender, SortType sortType, LocalDate date, Pageable pageable) {
         if (date != null) validateNotPastDate(date);
@@ -156,8 +165,21 @@ public class PostService {
 		Post post = dto.toEntity(currentUser);
 		post.setImageUrl(imageUrl);  // 이미지 URL 설정
 		
-		return postRepository.save(post);
-	}
+		Post saved = postRepository.save(post);
+
+        // 즉시 Redis에 초기 참가 인원( 작성자 포함으로 1) 세팅
+        String key = applicantKey(saved.getId());
+        try {
+            // 원하는 경우 setIfAbsent으로 바꿀 수 있음. 여기서는 단순 set.
+            redisTemplate.opsForValue().set(key, "1");
+            log.info("Initialized redis key {} = 1 for post {}", key, saved.getId());
+        } catch (Exception e) {
+            // Redis 실패는 DB 롤백과 무관하도록 로그만 남김
+            log.error("Failed to initialize redis key {} for post {}: {}", key, saved.getId(), e.getMessage(), e);
+        }
+
+        return saved;
+    }
 	
 	// 모집 글 상세 조회
 	public PostInfoResponseDto searchPost(Long postId, Long userId) {
@@ -285,23 +307,99 @@ public class PostService {
 	}
 	
 	 // helper to build currentPeopleMap from List<Long> ids
-    private Map<Long, Integer> buildCurrentPeopleMap(List<Long> ids) {
-        if (ids == null || ids.isEmpty()) return Collections.emptyMap();
-        List<Object[]> approvedCounts = participationRepository.countApprovedByPostIds(ids, ApplicationStatus.APPROVED);
-        Map<Long, Integer> currentPeopleMap = new HashMap<>();
-        
-        // 모든 postId를 1로 초기화 (작성자 포함)
-        for (Long postId : ids) {
-            currentPeopleMap.put(postId, 1);
-        }
-        
-        for (Object[] row : approvedCounts) {
-            Long postId = (Long) row[0];
-            Long count = (Long) row[1];
-            currentPeopleMap.put(postId, count.intValue()+1);
-        }
-        return currentPeopleMap;
-    }
+	public Map<Long, Integer> buildCurrentPeopleMap(List<Long> ids) {
+	    if (ids == null || ids.isEmpty()) return Collections.emptyMap();
+
+	    Map<Long, Integer> currentPeopleMap = new HashMap<>(ids.size());
+
+	    // 1) prepare keys and defaults
+	    List<String> keys = new ArrayList<>(ids.size());
+	    Map<String, Long> keyToPostId = new HashMap<>(ids.size());
+	    for (Long postId : ids) {
+	        String key = String.format(APPLICANT_KEY_FMT, postId);
+	        keys.add(key);
+	        keyToPostId.put(key, postId);
+	        // 기본값: 작성자 포함 1 (캐시/DB 둘다 없을 경우의 디폴트)
+	        currentPeopleMap.put(postId, 1);
+	    }
+
+	    List<Long> missingIds = new ArrayList<>();
+
+	    // 2) try multiGet from Redis
+	    List<String> values = null;
+	    try {
+	        values = redisTemplate.opsForValue().multiGet(keys);
+	    } catch (Exception e) {
+	        log.warn("Redis multiGet failed, falling back to DB for all ids: {}", e.getMessage());
+	        missingIds.addAll(ids);
+	        values = null;
+	    }
+
+	    if (values != null) {
+	        for (int i = 0; i < keys.size(); i++) {
+	            String key = keys.get(i);
+	            String value = values.get(i); // may be null
+	            Long postId = keyToPostId.get(key);
+
+	            if (value == null) {
+	                // 캐시 미스
+	                missingIds.add(postId);
+	                continue;
+	            }
+
+	            try {
+	                int parsed = Integer.parseInt(value); // Redis에는 '작성자 포함 총인원' 이 저장되어 있다고 가정
+	                currentPeopleMap.put(postId, parsed); // 그대로 반환
+	            } catch (NumberFormatException nfe) {
+	                log.warn("Invalid redis value for key {}: {}, fallback to DB", key, value);
+	                missingIds.add(postId);
+	            }
+	        }
+	    }
+
+	    // 3) DB에서 보정해야 할 postId들 처리
+	    if (!missingIds.isEmpty()) {
+	        // 배치로 DB에서 approved 수(작성자 제외) 집계
+	        List<Object[]> approvedCounts = participationRepository.countApprovedByPostIds(missingIds, ApplicationStatus.APPROVED);
+	        // approvedCounts: List of [postId, count] (count = 승인자 수, 작성자 제외)
+
+	        // touched: DB 결과에 등장한 postId들
+	        Set<Long> touched = new HashSet<>();
+	        for (Object[] row : approvedCounts) {
+	            Long postId = (Long) row[0];
+	            Long approvedCount = (Long) row[1]; // 작성자 제외 수
+
+	            int totalIncludingAuthor = approvedCount.intValue() + 1; // 작성자 포함
+	            currentPeopleMap.put(postId, totalIncludingAuthor);
+	            touched.add(postId);
+
+	            // Redis에 작성자 포함 총인원으로 초기화 (다른 프로세스가 이미 넣었을 수 있으니 setIfAbsent)
+	            String key = String.format(APPLICANT_KEY_FMT, postId);
+	            try {
+	                redisTemplate.opsForValue().setIfAbsent(key, String.valueOf(totalIncludingAuthor), Duration.ofMinutes(APPLICANT_KEY_TTL_MINIUTES));
+	            } catch (Exception e) {
+	                log.warn("Failed to set redis key {} to {}: {}", key, totalIncludingAuthor, e.getMessage());
+	            }
+	        }
+
+	        // DB 결과에 없는 postId들 (approvedCount == 0) 은 작성자 포함 1 유지, Redis에 1로 초기화 시도
+	        for (Long postId : missingIds) {
+	            if (!touched.contains(postId)) {
+	                // approvedCount == 0
+	                currentPeopleMap.put(postId, 1); // 이미 기본값이 1이지만 명시적으로 다시 설정
+	                String key = String.format(APPLICANT_KEY_FMT, postId);
+	                try {
+	                    redisTemplate.opsForValue().setIfAbsent(key, "1", Duration.ofMinutes(APPLICANT_KEY_TTL_MINIUTES));
+	                } catch (Exception e) {
+	                    log.debug("Failed to set redis key {} to 1: {}", key, e.getMessage());
+	                }
+	            }
+	        }
+	    }
+
+	    return currentPeopleMap;
+	}
+
 
     // sort by proximity to now (closest upcoming first)
     private List<Post> sortPostsByDate(List<Post> posts) {
@@ -422,6 +520,10 @@ public class PostService {
     public void expirePosts() {
         LocalDateTime now = LocalDateTime.now(); // timezone 고려 (아래 참조)
         int updated = postRepository.markExpired(now, Status.EXPIRED, Status.OPEN);
+    }
+    
+    private String applicantKey(Long postId) {
+        return String.format(APPLICANT_KEY_FMT, postId);
     }
     
 }

--- a/src/main/java/com/matchFit/post/service/PostService.java
+++ b/src/main/java/com/matchFit/post/service/PostService.java
@@ -212,22 +212,38 @@ public class PostService {
 	
 	@Transactional(readOnly = true)
 	public GetMyPosts getMyPosts(@AuthenticationPrincipal CustomUserDetails userDetails) {
-		User currentUser = userDetails.getUser();
-	    System.out.println("currentUser = " + currentUser.getId());
-        List<Post> posts = postRepository.findByUserIdOrderByCreatedAtDesc(currentUser.getId());
-        System.out.println("posts = " + posts);
-        List<GetMyPost> myPosts = posts.stream()
-            .map(post -> new GetMyPost(
-            		post.getId(), 
-                    post.getTitle(),
-                    post.getDate(),
-                    participationRepository.countByPost_IdAndStatus(post.getId(),ApplicationStatus.APPROVED)+1,
-                    post.getMaxPeople(),
-                    post.getStatus().name()
-            ))
-            .collect(Collectors.toList());
-        return GetMyPosts.of(myPosts);
-    }
+	    User currentUser = userDetails.getUser();
+	    List<Post> posts = postRepository.findByUserIdOrderByCreatedAtDesc(currentUser.getId());
+
+	    List<GetMyPost> myPosts = posts.stream()
+	        .map(post -> {
+	            String key = applicantKey(post.getId()); // applicantKey 활용
+	            String cachedValue = redisTemplate.opsForValue().get(key);
+
+	            int currentPeople;
+	            if (cachedValue != null) {
+	                currentPeople = Integer.parseInt(cachedValue);
+	            } else {
+	                // fallback: DB 조회 (승인된 인원 + 작성자)
+	                currentPeople = participationRepository.countByPost_IdAndStatus(
+	                        post.getId(),
+	                        ApplicationStatus.APPROVED
+	                ) + 1;
+	            }
+
+	            return new GetMyPost(
+	                post.getId(),
+	                post.getTitle(),
+	                post.getDate(),
+	                currentPeople,
+	                post.getMaxPeople(),
+	                post.getStatus().name()
+	            );
+	        })
+	        .collect(Collectors.toList());
+
+	    return GetMyPosts.of(myPosts);
+	}
 	
 	// 모집글 수정
 	@Transactional


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactoring/posts-get-applicants

### 🔑 주요 변경사항
- 참가 인원 수락 시, 현재 인원 카운팅 redis에 저장
- 모집글 생성 시, 현재 인원 1로 redis에 저장 
- 모집글 목록 조회 시, Cache Hit면 현재 인원 redis에서 조회, Cache Miss면 DB에서 조회

### 🏞 스크린샷
<img width="1047" height="293" alt="image" src="https://github.com/user-attachments/assets/77638d1c-a839-4cf9-97d9-b95da1544c31" />

### 관련 이슈
- https://github.com/CLD-3rd/Final-Team3/issues/91
